### PR TITLE
fixed anno-plass version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
             <dependency>
                 <groupId>net.anotheria</groupId>
                 <artifactId>ano-plass</artifactId>
-                <version>2.0.1</version>
+                <version>2.1.1</version>
             </dependency>
             <dependency>
                 <groupId>net.anotheria</groupId>


### PR DESCRIPTION
net.anotheria.anoplass.api.AbstractAPIImpl class of anno-plass package not contain protected field `log` in version 2.0.1 (that been used previously), but this field is used by net.anotheria.moskito.webui.dashboards.api.DashboardAPIImpl. Version is set to 2.1.1 (as webui require)