### PR TITLE
aop.xml excluded from meta-inf during shade execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,8 @@
                                     <excludes>
                                         <!-- exclude aop - as it placed into META-INF-->
                                         <exclude>aop.xml</exclude>
+                                        <exclude>META-INF/aop.xml</exclude>
+
                                         <!-- exclude m-k static resources-->
                                         <exclude>moskito/**</exclude>
                                         <!-- exclude logback - as it wil be provided from configuration/-->

--- a/pom.xml
+++ b/pom.xml
@@ -409,8 +409,8 @@
                                         <exclude>**/*.json</exclude>
 
                                         <!-- exclude signatures  -->
-                                        <exclude>META-INF/BCKEY.SF</exclude>
-                                        <exclude>META-INF/BCKEY.DSA</exclude>
+                                    <!--<exclude>META-INF/BCKEY.SF</exclude>-->
+                                    <!--<exclude>META-INF/BCKEY.DSA</exclude>-->
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
Excluding aop.xml from Meta-Inf during shade!